### PR TITLE
Update run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -52,8 +52,8 @@ if pppwn_ps4_run; then
 	wifi reload
 	# Commit changes
 	/etc/init.d/network reload
-	echo "[DISABLED] INTERFACE WAN & WAN6 & WIFI"
-	echo "YOU HAVEN'T ACCESS TO INTERNET"
+	echo "[ENABLED] INTERFACE WAN & WAN6 & WIFI"
+	echo "YOU HAVE GRANTED ACCESS TO INTERNET"
 else
 	# Disable WAN and WAN6 interface
 	ifdown wan && ifdown wan6
@@ -66,8 +66,8 @@ else
 	wifi reload
 	# Commit changes
 	/etc/init.d/network reload
-	echo "[ENABLED] INTERFACE WAN & WAN6 & WIFI"
-	echo "YOU HAVE GRANTED ACCESS TO INTERNET"
+	echo "[DISABLED] INTERFACE WAN & WAN6 & WIFI"
+	echo "YOU HAVEN'T ACCESS TO INTERNET"
 	echo
 fi
 echo "none" > /sys/class/leds/red:info/trigger


### PR DESCRIPTION
Auto disabling WAN and WIFI interface to prevent Internet access to prefent accidental PS4 system updates before jailbreaking

While script started at first disable internet access to prevent PS4 system updates

While script run pppwn_{architecture} finished without problems (return 0 into "pppwn_ps4_run") then restores access to the Internet, but while any problems will occur when executing the script to be sure, it will again cut off access to the Internet by disabling interfaces 

(although I assume that by then it might be too late, although this should not be the case due to the fact that at the beginning of the script we turn off the WAN, WAN6 and WIFI network interfaces)

@MODDEDWARFARE  - Due to MIPS issues I cannot fully test this. Requires additional testing.
However, it would be nice to block Internet access when the router starts up